### PR TITLE
Updating resty-newrelic rockspect to use https

### DIFF
--- a/resty-newrelic-0.01-1.rockspec
+++ b/resty-newrelic-0.01-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-newrelic"
 version = "0.01-1"
 source = {
-   url = "git://github.com/saks/lua-resty-newrelic",
+   url = "https://github.com/saks/lua-resty-newrelic/archive/master.zip",
    tag = "v0.01"
 }
 description = {


### PR DESCRIPTION
We were having firewall issue of unable to accept git protocol and hence requesting you to change it to https.
Please accept this merge reqeust