### PR TITLE
Change log level when logging sucessful connection

### DIFF
--- a/lib/resty/newrelic_agent.lua
+++ b/lib/resty/newrelic_agent.lua
@@ -13,7 +13,7 @@ _M.enable = function()
   if _M.enabled then
     newrelic.embed_collector()
     newrelic.init(license_key, app_name, 'lua', '-')
-    ngx.log(ngx.ERR, 'Starting newrelic agent.')
+    ngx.log(ngx.INFO, 'Starting newrelic agent.')
   else
     ngx.log(ngx.ERR, 'Newrelic agent is not configured')
   end


### PR DESCRIPTION
For readability it's possible to reduce the log level of a sucessful connection from ERR to INFO.
It will avoid polute the logs with a message of success per worker.